### PR TITLE
Add Redis object caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A minimal Docker configuration for WordPress, optimized for Coolify deployment.
 
 - WordPress 6.4 with Apache
 - MySQL 8.0
+- Redis 7 for object caching
 - Coolify and Traefik ready
 - Minimal configuration for reliability
 
@@ -14,12 +15,19 @@ A minimal Docker configuration for WordPress, optimized for Coolify deployment.
 ### WordPress
 - Official WordPress image with Apache
 - Automatic database connection
+- Redis object caching integration
 - Volume persistence for uploads
 
 ### MySQL
 - MySQL 8.0
 - Native password authentication
 - Persistent data storage
+
+### Redis
+- 128MB memory limit
+- LRU eviction policy
+- Persistence enabled
+- Optimized for WordPress caching
 
 ## Usage
 
@@ -38,4 +46,4 @@ Requirements:
 
 - Port mapping handled by Traefik in Coolify
 - Data persistence through Docker volumes
-- Simplified configuration for reliability
+- Redis improves performance by caching database queries and objects

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,15 @@ services:
       WORDPRESS_DB_USER: wordpress
       WORDPRESS_DB_PASSWORD: wordpress_password
       WORDPRESS_DB_NAME: wordpress
+      WORDPRESS_CONFIG_EXTRA: |
+        define('WP_REDIS_HOST', 'redis');
+        define('WP_REDIS_PORT', 6379);
+        define('WP_CACHE', true);
     volumes:
       - wordpress:/var/www/html
     depends_on:
       - mysql
+      - redis
 
   mysql:
     image: mysql:8.0
@@ -24,6 +29,14 @@ services:
       - mysql:/var/lib/mysql
     command: --default-authentication-plugin=mysql_native_password
 
+  redis:
+    image: redis:7-alpine
+    volumes:
+      - redis:/data
+      - ./redis.conf:/usr/local/etc/redis/redis.conf
+    command: redis-server /usr/local/etc/redis/redis.conf
+
 volumes:
   wordpress:
   mysql:
+  redis:

--- a/redis.conf
+++ b/redis.conf
@@ -1,14 +1,9 @@
-maxmemory 256mb
+maxmemory 128mb
 maxmemory-policy allkeys-lru
 appendonly yes
 appendfsync everysec
-no-appendfsync-on-rewrite yes
-auto-aof-rewrite-percentage 100
-auto-aof-rewrite-min-size 64mb
 save 900 1
 save 300 10
 save 60 10000
 tcp-keepalive 300
-databases 2
-rdbcompression yes
-rdbchecksum yes
+databases 1


### PR DESCRIPTION
Closes #1

Implemented Redis object caching with:
- Conservative 128MB memory limit
- LRU eviction policy
- Persistence for reliability
- WordPress Redis Object Cache plugin compatibility

Tested and verified:
- WordPress installation successful
- Redis server detected by plugin
- Object caching functional