### PR TITLE
feat: Upgrade to PHP 8.2

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   wordpress:
-    image: wordpress:latest
+    image: wordpress:php8.2
     environment:
       WORDPRESS_DB_HOST: mysql
       WORDPRESS_DB_USER: wordpress


### PR DESCRIPTION
This PR upgrades WordPress to use PHP 8.2.

Changes:
- Updated WordPress container to use php8.2 tag

This change is already reflected in our docker-compose.yaml and has been tested in production via Coolify.